### PR TITLE
chore: update @lando/php to ^1.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Updated `@lando/php` to `^1.11.0` for MySQL client auto-detection fix
+
 ## v1.10.0 - [February 18, 2026](https://github.com/lando/joomla/releases/tag/v1.10.0)
 
 * Updated to [@lando/php@1.10.0](https://github.com/lando/php/releases/tag/v1.10.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
-* Updated `@lando/php` to `^1.11.0` for MySQL client auto-detection fix
+* Updated `@lando/php` to `^1.11.1`
 
 ## v1.10.0 - [February 18, 2026](https://github.com/lando/joomla/releases/tag/v1.10.0)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@lando/joomla",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lando/joomla",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "@lando/mariadb": "^1.7.0",
         "@lando/mssql": "^1.4.3",
         "@lando/mysql": "^1.6.0",
-        "@lando/php": "^1.10.0",
+        "@lando/php": "^1.11.0",
         "@lando/postgres": "^1.5.0",
         "lodash": "^4.17.21"
       },
@@ -1472,9 +1472,9 @@
       "license": "MIT"
     },
     "node_modules/@lando/php": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@lando/php/-/php-1.10.0.tgz",
-      "integrity": "sha512-1+WO35CixeaZKaQ+NTi+Xii1xk+GYIJvbbqVI1Ba10RFMBTsUK4y99hZCKrCLW3KqPfe6f4ufAfMllALbnHHmw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@lando/php/-/php-1.11.0.tgz",
+      "integrity": "sha512-E2uj58X1+Kk+XYnDhpnl04nR60/lBt/jwhmhNPryis6t9EwMDLDJ8YI8UUjVSxvUL1NbVlYp4X90Rc3EHsWv1g==",
       "bundleDependencies": [
         "@lando/nginx",
         "lodash",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@lando/mariadb": "^1.7.0",
         "@lando/mssql": "^1.4.3",
         "@lando/mysql": "^1.6.0",
-        "@lando/php": "^1.11.0",
+        "@lando/php": "^1.11.1",
         "@lando/postgres": "^1.5.0",
         "lodash": "^4.17.21"
       },
@@ -1472,9 +1472,9 @@
       "license": "MIT"
     },
     "node_modules/@lando/php": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@lando/php/-/php-1.11.0.tgz",
-      "integrity": "sha512-E2uj58X1+Kk+XYnDhpnl04nR60/lBt/jwhmhNPryis6t9EwMDLDJ8YI8UUjVSxvUL1NbVlYp4X90Rc3EHsWv1g==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@lando/php/-/php-1.11.1.tgz",
+      "integrity": "sha512-3l6oEj6iZxL4vj59YbOinfu4ktUXYfHe7UlP1W5wePTaQH9K+RBCg8eCsPBmliQzc9ltX6JqvDYrAx2KN5K8Dw==",
       "bundleDependencies": [
         "@lando/nginx",
         "lodash",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@lando/mariadb": "^1.7.0",
     "@lando/mssql": "^1.4.3",
     "@lando/mysql": "^1.6.0",
-    "@lando/php": "^1.10.0",
+    "@lando/php": "^1.11.0",
     "@lando/postgres": "^1.5.0",
     "lodash": "^4.17.21"
   },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@lando/mariadb": "^1.7.0",
     "@lando/mssql": "^1.4.3",
     "@lando/mysql": "^1.6.0",
-    "@lando/php": "^1.11.0",
+    "@lando/php": "^1.11.1",
     "@lando/postgres": "^1.5.0",
     "lodash": "^4.17.21"
   },


### PR DESCRIPTION
Updates @lando/php to ^1.11.1 for MySQL client auto-detection fix in recipe-based services (lando/php#223).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk dependency bump only; behavior changes are limited to whatever `@lando/php@1.11.1` alters in the underlying PHP service (e.g., MySQL client detection).
> 
> **Overview**
> Updates this plugin’s PHP runtime dependency by bumping `@lando/php` from `^1.10.0` to `^1.11.1`, including the corresponding `package-lock.json` refresh.
> 
> Adds an unreleased changelog entry documenting the `@lando/php` upgrade.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45563fa6dc097dab021be8aea909f0aeceeb51e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->