### PR TITLE
feat: promote npm edge tag to latest when prerelease is promoted

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,32 @@ on:
   release:
     types:
       - published
-
+      - released
 jobs:
+  # When a prerelease is promoted to a full release, update the npm latest tag
+  promote:
+    if: github.event.action == 'released'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Install node 20
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          registry-url: https://registry.npmjs.org
+      - name: Promote edge to latest
+        run: |
+          VERSION=$(echo "$TAG_NAME" | sed 's/^v//')
+          PACKAGE=$(node -p "require('./package.json').name")
+          npm dist-tag add "$PACKAGE@$VERSION" latest
+          echo "::notice title=Promoted $VERSION to latest::The latest tag now points to $VERSION (was edge-only)"
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_DEPLOY_TOKEN}}
+
   deploy:
+    if: github.event.action == 'published'
     runs-on: ${{ matrix.os }}
     env:
       TERM: xterm


### PR DESCRIPTION
## Problem

When a release is published as a prerelease, it gets tagged as `edge` on npm. Later, when the release is promoted to a full release in GitHub, the npm `latest` tag doesn't update because the workflow only triggered on `published`.

## Solution

- Added `released` to the release workflow trigger types
- New lightweight `promote` job that only runs `npm dist-tag add latest` — no install, no lint, no tests, no re-publish
- Only fires on the `released` event (when a prerelease is promoted to full release)
- Existing `deploy` job is now explicitly gated to `published` events only (no behavior change)
- Uses `TAG_NAME` env var instead of direct interpolation to prevent script injection

## Flow

1. Publish as prerelease → full pipeline runs, publishes with `edge` tag (unchanged)
2. Promote release → uncheck prerelease → `promote` job runs, points `latest` to that version (~15s)

The `dist-tag add` command is idempotent, so if both `published` and `released` fire on a fresh non-prerelease publish, the redundant promote is harmless.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change affecting npm dist-tag management; risk is limited to potentially mis-tagging `latest` if the release tag/version is incorrect or the token permissions are misconfigured.
> 
> **Overview**
> Updates the release workflow to also trigger on GitHub `release.released` events and adds a new `promote` job that runs `npm dist-tag add ... latest` based on the release tag, allowing prereleases previously published under `edge` to be promoted to `latest` without re-publishing.
> 
> The existing `deploy` publish pipeline is now explicitly gated to only run on `release.published`, reducing the chance of duplicate publish runs when a release is later promoted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5d59ca005b8c84f7fbebb6466b95f4954ba04ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->