### PR TITLE
test: validate ANSI escape codes are not in redirected composer output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Removed `--ansi` flag from composer tooling command to prevent escape codes in redirected output
+
 ## v1.10.0 - [February 20, 2026](https://github.com/lando/joomla/releases/tag/v1.10.0)
 
 * Updated `@lando/php` to `^1.11.1`

--- a/builders/joomla.js
+++ b/builders/joomla.js
@@ -16,7 +16,7 @@ const getDatabaseType = options => {
 const toolingDefaults = {
   'composer': {
     service: 'appserver',
-    cmd: 'composer --ansi',
+    cmd: 'composer',
   },
   'db-import <file>': {
     service: ':host',

--- a/examples/joomla-defaults/README.md
+++ b/examples/joomla-defaults/README.md
@@ -41,6 +41,8 @@ lando mysql joomla -e quit
 # Should use composer 2 by default
 lando exec appserver -- /bin/sh -c 'NO_COLOR=1 composer -V' | grep "Composer version 2."
 
+# Should not include ANSI escape codes when output is redirected
+lando composer --version > /tmp/composer-output.txt 2>&1 && ! grep -P '\x1b\[' /tmp/composer-output.txt
 # Should use the correct default config files
 lando exec appserver -- cat /usr/local/etc/php/conf.d/zzz-lando-my-custom.ini | grep "; LANDOJOOMLAPHPINI"
 lando exec appserver -- curl -L http://localhost/info.php | grep max_execution_time | grep 91


### PR DESCRIPTION
Adds a test that verifies `lando composer --version > file.txt` does not contain ANSI escape codes in the output file.

**This test is expected to FAIL** on CI until the fix is applied — removing `--ansi` from the composer tooling command.

The root cause is `--ansi` being hardcoded in the composer tooling definition. Composer auto-detects TTY when `--ansi` isn't forced.

Ref lando/drupal#157

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to the default `composer` tooling command plus an example verification check; the main risk is any downstream reliance on forced ANSI formatting in composer output.
> 
> **Overview**
> Stops forcing ANSI output for the default `composer` tooling by removing the hardcoded `--ansi` flag, so redirected output (eg `lando composer --version > file`) no longer contains escape codes.
> 
> Adds an example verification command to assert redirected composer output is free of ANSI escape sequences, and notes the change in the unreleased changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ad500c08e1d575de0d33437c2c1453d9c02ad33. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->