### PR TITLE
fix: remove hardcoded mysql_native_password for MySQL 8.4 compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
 * Removed `--ansi` flag from composer tooling command to prevent escape codes in redirected output
+* Fixed MySQL 8.4 startup failure by removing hardcoded `mysql_native_password` authentication [lando/mysql#69](https://github.com/lando/mysql/issues/69)
 
 ## v1.10.0 - [February 20, 2026](https://github.com/lando/joomla/releases/tag/v1.10.0)
 

--- a/builders/joomla.js
+++ b/builders/joomla.js
@@ -148,7 +148,6 @@ const getServices = options => ({
   },
   database: {
     config: getServiceConfig(options, ['database']),
-    authentication: 'mysql_native_password',
     type: `joomla-${options.database}`,
     portforward: true,
     creds: {

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,7 +10,7 @@
 [[context.deploy-preview.plugins]]
   package = "netlify-plugin-checklinks"
   [context.deploy-preview.plugins.inputs]
-    todoPatterns = [ "load", "CHANGELOG.html", "x.com", "twitter.com", "/v/" ]
+    todoPatterns = [ "load", "CHANGELOG.html", "x.com", "twitter.com", "/v/", "hub.docker.com" ]
     skipPatterns = [ ".rss", ".gif", ".jpg" ]
     checkExternal = true
 


### PR DESCRIPTION
## Summary

MySQL 8.4 removed the `default_authentication_plugin` config variable (deprecated in 8.0.34, removed in 8.4). The bitnami image translates the `MYSQL_AUTHENTICATION_PLUGIN` env var into this config entry, causing MySQL 8.4 to fail with:

```
[ERROR] [MY-000067] [Server] unknown variable 'default_authentication_plugin=mysql_native_password'
```

## Changes

- Removed hardcoded `authentication: 'mysql_native_password'` from the recipe database config
- The `lando/mysql` plugin already handles the 5.7 case internally (`builders/mysql.js:42`), so recipes don't need to set this

## Backwards Compatibility

- **MySQL 5.7**: ✅ Unaffected — the mysql plugin forces `mysql_native_password` for 5.7
- **MySQL 8.0-8.3**: ✅ Uses `caching_sha2_password` by default (correct modern auth)
- **MySQL 8.4+**: ✅ No longer crashes on startup

## Related

- lando/mysql#69
- lando/mysql#72
- Companion PR in `lando/mysql` to conditionally set the env var

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes database service authentication behavior across MySQL versions; could affect connection/login expectations for existing projects if they relied on the previous forced plugin.
> 
> **Overview**
> Fixes MySQL 8.4 startup by removing the recipe’s hardcoded `authentication: 'mysql_native_password'` from the Joomla `database` service, allowing the underlying MySQL plugin/image defaults to take effect.
> 
> Also updates `CHANGELOG.md` to document the MySQL 8.4 fix, and tweaks Netlify deploy-preview link checking to ignore `hub.docker.com` in `todoPatterns`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 228397514816a4894379077f6e3b48a1b7176a37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->